### PR TITLE
Don't override Field.name if already set

### DIFF
--- a/mongotor/orm/collection.py
+++ b/mongotor/orm/collection.py
@@ -37,7 +37,8 @@ class CollectionMetaClass(type):
         # Add the document's fields to the _data
         for attr_name, attr_value in attrs.items():
             if hasattr(attr_value, "__class__") and\
-                issubclass(attr_value.__class__, Field):
+                    issubclass(attr_value.__class__, Field) and\
+                    attr_value.name is None:
 
                 attr_value.name = attr_name
 


### PR DESCRIPTION
Currently 'name' of `Field` properties is ignored during class initialization.

```
class User(Collection)
    address = StringField(name='addr')

print User.address.name  # prints 'address' not 'addr'
```
