### PR TITLE
Allow callable default for Fields

### DIFF
--- a/mongotor/orm/field.py
+++ b/mongotor/orm/field.py
@@ -36,7 +36,7 @@ class Field(object):
 
         value = instance._data.get(self.name)
         if value is None:
-            return self.default
+            return self.default() if callable(self.default) else self.default
 
         return value
 


### PR DESCRIPTION
It would be nice that `default` of a `Field` can be callable (like other popular ORMs)
