### PR TITLE
Don't call `_config_nodes` when another `_config_nodes` is in progress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+
+script:
+ - pip install -r requirements-dev.txt
+ - make mongo-start
+ - make mongo-config
+ - python setup.py build
+ - make test
+

--- a/Makefile
+++ b/Makefile
@@ -10,31 +10,47 @@ MONGOD=mongod
 MONGO_DATA=`pwd`/data
 
 mongo-start-node1:
-	${MONGOD} --port=27027 --dbpath=${MONGO_DATA}/db/node1 --replSet=mongotor --logpath=${MONGO_DATA}/log/node1.log --fork --smallfiles
+	${MONGOD} --port=27027 --dbpath=${MONGO_DATA}/db/node1 --replSet=mongotor --logpath=${MONGO_DATA}/log/node1.log --fork --smallfiles --oplogSize 30 --nojournal
 
 mongo-start-node2:
-	${MONGOD} --port=27028 --dbpath=${MONGO_DATA}/db/node2 --replSet=mongotor --logpath=${MONGO_DATA}/log/node2.log --fork --smallfiles
+	${MONGOD} --port=27028 --dbpath=${MONGO_DATA}/db/node2 --replSet=mongotor --logpath=${MONGO_DATA}/log/node2.log --fork --smallfiles --oplogSize 30 --nojournal
 
 mongo-start-arbiter:
-	${MONGOD} --port=27029 --dbpath=${MONGO_DATA}/db/arbiter --replSet=mongotor --logpath=${MONGO_DATA}/log/arbiter.log --fork --smallfiles
+	${MONGOD} --port=27029 --dbpath=${MONGO_DATA}/db/arbiter --replSet=mongotor --logpath=${MONGO_DATA}/log/arbiter.log --fork --smallfiles --oplogSize 30 --nojournal
 
-mongo-start: mongo-kill
+mongo-restart: mongo-kill mongo-start
+
+mongo-start:
 	mkdir -p ${MONGO_DATA}/db/node1 ${MONGO_DATA}/db/node2 ${MONGO_DATA}/db/arbiter ${MONGO_DATA}/log
 	
 	echo "starting mongo instance"
 	make mongo-start-node1
 	make mongo-start-node2
 	make mongo-start-arbiter
-	sleep 5
+	echo 'Waiting 10s for `mongod`s to start'
+	sleep 10
+
+mongo-kill-node1:
+	ps -eo pid,args | grep 27027 | grep ${MONGO_DATA} | grep -v grep | awk '{print $$1}' | xargs kill 2> /dev/null | true
+
+mongo-kill-node2:
+	ps -eo pid,args | grep 27028 | grep ${MONGO_DATA} | grep -v grep | awk '{print $$1}' | xargs kill 2> /dev/null | true
+
+mongo-kill-arbiter:
+	ps -eo pid,args | grep 27029 | grep ${MONGO_DATA} | grep -v grep | awk '{print $$1}' | xargs kill 2> /dev/null | true
 
 mongo-kill:
 	echo "killing mongo instance"
-	ps -ef | grep mongo | grep -v grep | grep ${MONGO_DATA} | tr -s ' ' | cut -d ' ' -f 3 | xargs kill 2> /dev/null | true
-	echo 'Waiting for `mongod`s to stop'
-	sleep 5
+	make mongo-kill-node1
+	make mongo-kill-node2
+	make mongo-kill-arbiter
+	echo 'Waiting 1s for `mongod`s to stop'
+	sleep 1
 
 mongo-config:
 	mongo localhost:27027 < config-replicaset.js
+	echo 'Waiting 40s to let replicaset elect a primary'
+	sleep 40
 
 install_deps:
 	pip install -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,18 @@ MONGOD=mongod
 MONGO_DATA=`pwd`/data
 
 mongo-start-node1:
-	${MONGOD} --port=27027 --dbpath=${MONGO_DATA}/db/node1 --replSet=mongotor --logpath=${MONGO_DATA}/log/node1.log --fork
+	${MONGOD} --port=27027 --dbpath=${MONGO_DATA}/db/node1 --replSet=mongotor --logpath=${MONGO_DATA}/log/node1.log --fork --smallfiles
 
 mongo-start-node2:
-	${MONGOD} --port=27028 --dbpath=${MONGO_DATA}/db/node2 --replSet=mongotor --logpath=${MONGO_DATA}/log/node2.log --fork
+	${MONGOD} --port=27028 --dbpath=${MONGO_DATA}/db/node2 --replSet=mongotor --logpath=${MONGO_DATA}/log/node2.log --fork --smallfiles
 
 mongo-start-arbiter:
-	${MONGOD} --port=27029 --dbpath=${MONGO_DATA}/db/arbiter --replSet=mongotor --logpath=${MONGO_DATA}/log/arbiter.log --fork
+	${MONGOD} --port=27029 --dbpath=${MONGO_DATA}/db/arbiter --replSet=mongotor --logpath=${MONGO_DATA}/log/arbiter.log --fork --smallfiles
 
 mongo-start: mongo-kill
 	mkdir -p ${MONGO_DATA}/db/node1 ${MONGO_DATA}/db/node2 ${MONGO_DATA}/db/arbiter ${MONGO_DATA}/log
 	
-	echo "startin mongo instance"
+	echo "starting mongo instance"
 	make mongo-start-node1
 	make mongo-start-node2
 	make mongo-start-arbiter
@@ -29,7 +29,8 @@ mongo-start: mongo-kill
 
 mongo-kill:
 	echo "killing mongo instance"
-	ps -ef | grep mongo | grep -v grep | grep ${MONGO_DATA} | tr -s ' ' | cut -d ' ' -f 3 | xargs kill -9
+	ps -ef | grep mongo | grep -v grep | grep ${MONGO_DATA} | tr -s ' ' | cut -d ' ' -f 3 | xargs kill 2> /dev/null | true
+	echo 'Waiting for `mongod`s to stop'
 	sleep 5
 
 mongo-config:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 (MONGOdb + TORnado) is an asynchronous toolkit for working with ``mongodb`` inside a ``tornado`` app. Mongotor has a pure implementation of python + tornado and only depends on tornado and bson (provided by pymongo)
 
+[![Build Status](https://travis-ci.org/marcelnicolay/mongotor.svg?branch=master)](https://travis-ci.org/marcelnicolay/mongotor)
+
 ## Features
 
 MongoTor is still an alpha project, but already implements the following features:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -73,8 +73,12 @@ class DatabaseTestCase(testing.AsyncTestCase):
         """[DatabaseTestCase] - Raises DatabaseError when could not find valid nodes"""
 
         database = Database.init(["localhost:27030"], dbname='test')
-        database.send_message.when.called_with("", callback=None) \
-            .throw(DatabaseError, 'could not find an available node')
+
+        def send_message():
+            database.send_message('', callback=self.stop)
+            self.wait()
+
+        send_message.when.called.throw(DatabaseError, 'could not find an available node')
 
     def test_run_command(self):
         """[DatabaseTestCase] - Run a database command"""

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -40,11 +40,8 @@ class ReplicaSetTestCase(testing.AsyncTestCase):
 
     def test_raises_error_when_mode_is_secondary_and_secondary_is_down(self):
         """[ReplicaSetTestCase] - Raise error when mode is secondary and secondary is down"""
-        os.system('make mongo-kill > /dev/null 2>&1')
-        os.system('make mongo-start-node1')
-        os.system('make mongo-start-arbiter')
-
-        time.sleep(10)
+        os.system('make mongo-kill-node2')
+        time.sleep(1)  # stops are fast
 
         try:
             db = Database.init(["localhost:27027", "localhost:27028"], dbname='test')
@@ -56,7 +53,7 @@ class ReplicaSetTestCase(testing.AsyncTestCase):
                 .throw(DatabaseError)
         finally:
             os.system('make mongo-start-node2')
-            time.sleep(10)
+            time.sleep(5)  # wait to become secondary again
 
 
 class SecondaryPreferredTestCase(testing.AsyncTestCase):


### PR DESCRIPTION
If we call `get_node` twice before starting IOLoop, `_config_nodes` will be called twice, and therefore subsequent `_config_nodes` will be called twice every 30-seconds.

This pull request, also three trivial fix commits.
