### PR TITLE
Use `Node`'s connection pool when (re)configuring node

### DIFF
--- a/mongotor/node.py
+++ b/mongotor/node.py
@@ -63,7 +63,7 @@ class Node(object):
                 connection = Connection(host=self.host, port=self.port)
             response, error = yield gen.Task(self.database._command, ismaster,
                 connection=connection)
-            if not connection.pool:  # if connection is created on the fly
+            if not connection._pool:  # if connection is created on the fly
                 connection.close()
         except InterfaceError, ie:
             logger.error('oops, database node {host}:{port} is unavailable: {error}' \


### PR DESCRIPTION
By default each `Node` creates and closes one connection every 30 seconds. This generates lots of open connections (TIME_WAIT status) on a Linux mongodb server.

By using connection pool for these queries, lots of connection accept/close cycles are saved.
