### PR TITLE
Fix using a field name different from attribute name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ data
 
 #PyCharm
 .idea/
+
+#Sublime
+*.sublime-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - 2.6
+  #- 2.6
   - 2.7
-  - pypy
+  #- pypy
   - 3.2
   - 3.3
   - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,17 @@ language: python
 python:
   - 2.6
   - 2.7
-  #- pypy, sure is incompatible with pypy
+  - pypy
   - 3.2
   - 3.3
   - 3.4
 
-script:
+install:
+ - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
  - pip install -r requirements-dev.txt
  - make mongo-start
  - make mongo-config
  - python setup.py build
+
+script:
  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - 2.6
   - 2.7
-  - pypy
-  - 3.2
+  #- pypy, sure is incompatible with pypy
+  #- 3.2, does not support unicode literals (u'')
   - 3.3
   - 3.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 2.6
   - 2.7
   #- pypy, sure is incompatible with pypy
-  #- 3.2, does not support unicode literals (u'')
+  - 3.2
   - 3.3
   - 3.4
 
@@ -13,4 +13,3 @@ script:
  - make mongo-config
  - python setup.py build
  - make test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 python:
-  - "2.7"
+  - 2.6
+  - 2.7
+  - pypy
+  - 3.2
+  - 3.3
+  - 3.4
 
 script:
  - pip install -r requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The next steps are provide support to:
 * authentication
 * nearest preference in replica sets
 * gridfs
-* all python versions (2.5, 2.6, 2.7, 3.2 and PyPy), only python 2.7 is tested now
+* all python versions (2.6, 2.7, 3.2 and PyPy), only python 2.7 is tested now
 
 ## Documentation
 
@@ -67,7 +67,7 @@ class Handler(tornado.web.RequestHandler):
     def get(self):
         user = {'_id': ObjectId(), 'name': 'User Name'}
         yield gen.Task(self.db.user.insert, user)
-        
+
         yield gen.Task(self.db.user.update, user['_id'], {"$set": {'name': 'New User Name'}})
 
         user_found = yield gen.Task(self.db.user.find_one, user['_id'])
@@ -98,10 +98,10 @@ class Handler(tornado.web.RequestHandler):
     @gen.engine
     def get(self):
         user = {'_id': ObjectId()}
-        
+
         # write on primary
         yield gen.Task(self.db.user.insert, user)
-        
+
         # wait for replication
         time.sleep(2)
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,7 +12,7 @@ MongoTor supports installation using standard Python "distutils" or
 Install via easy_install or pip
 -------------------------------
 
-When ``easy_install`` or ``pip`` is available, the distribution can be 
+When ``easy_install`` or ``pip`` is available, the distribution can be
 downloaded from Pypi and installed in one step::
 
     easy_install mongotor
@@ -39,11 +39,13 @@ Python prompt like this:
 
 .. sourcecode:: python
 
-     >>> import mongotor 
+     >>> import mongotor
      >>> mongotor.version # doctest: +SKIP
 
 Requirements
 ------------
+
+Python version 2.6+ is required. But only version 2.7 is tested for now.
 
 The following three python libraries are required.
 

--- a/mongotor/__init__.py
+++ b/mongotor/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-version = "0.1.0"
+version = "0.1.2"

--- a/mongotor/__init__.py
+++ b/mongotor/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-version = "0.1.3"
+version = "0.1.4"

--- a/mongotor/__init__.py
+++ b/mongotor/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-version = "0.1.4"
+version = "0.1.5"

--- a/mongotor/__init__.py
+++ b/mongotor/__init__.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-version = "0.1.2"
+version = "0.1.3"

--- a/mongotor/client.py
+++ b/mongotor/client.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 from bson.code import Code
+import six
 from tornado import gen
 from mongotor.node import ReadPreference
 from mongotor.cursor import Cursor
@@ -291,7 +292,7 @@ class Client(object):
         """
 
         group = {}
-        if isinstance(key, basestring):
+        if isinstance(key, six.string_types):
             group["$keyf"] = Code(key)
         elif key is not None:
             group = {"key": helpers._fields_list_to_dict(key)}

--- a/mongotor/connection.py
+++ b/mongotor/connection.py
@@ -54,7 +54,7 @@ class Connection(object):
             self._stream.set_close_callback(self._socket_close)
 
             self._connected = True
-        except socket.error, error:
+        except socket.error as error:
             raise InterfaceError(error)
 
     def __repr__(self):
@@ -156,7 +156,7 @@ class Connection(object):
     def close_on_error(self):
         try:
             yield
-        except DatabaseError, de:
+        except DatabaseError as de:
             logger.error('database error'.format(de))
             raise
         except Exception:

--- a/mongotor/cursor.py
+++ b/mongotor/cursor.py
@@ -95,8 +95,8 @@ class Cursor(object):
         else:
             callback((response['data'], None))
 
-    @gen.engine
-    def count(self, callback):
+    @gen.coroutine
+    def count(self):
         """Get the size of the results set for this query.
 
         Returns the number of documents in the results set for this query. Does
@@ -110,7 +110,7 @@ class Cursor(object):
         if response and len(response) > 0 and 'n' in response:
             total = int(response['n'])
 
-        callback(total)
+        raise gen.Return(total)
 
     @gen.engine
     def distinct(self, key, callback):

--- a/mongotor/cursor.py
+++ b/mongotor/cursor.py
@@ -112,8 +112,8 @@ class Cursor(object):
 
         raise gen.Return(total)
 
-    @gen.engine
-    def distinct(self, key, callback):
+    @gen.coroutine
+    def distinct(self, key):
         """Get a list of distinct values for `key` among all documents
         in the result set of this query.
 
@@ -131,7 +131,7 @@ class Cursor(object):
         response, error = yield gen.Task(self._database.command,
             'distinct', self._collection, **command)
 
-        callback(response['values'])
+        raise gen.Return(response['values'])
 
     def _query_options(self):
         """Get the query options string to use for this query."""

--- a/mongotor/cursor.py
+++ b/mongotor/cursor.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
+import six
 from tornado import gen
 from bson import SON
 from mongotor import message
@@ -120,9 +121,8 @@ class Cursor(object):
         :Parameters:
           - `key`: name of key for which we want to get the distinct values
         """
-        if not isinstance(key, basestring):
-            raise TypeError("key must be an instance "
-                            "of %s" % (basestring.__name__,))
+        if not isinstance(key, six.string_types):
+            raise TypeError("key must be a string (str/unicode)")
 
         command = {"key": key}
         if self._spec:

--- a/mongotor/database.py
+++ b/mongotor/database.py
@@ -17,6 +17,7 @@
 
 from functools import partial, wraps
 from datetime import timedelta
+import six
 from tornado import gen
 from tornado.ioloop import IOLoop
 from bson import SON
@@ -124,7 +125,7 @@ class Database(object):
         return u'%s.%s' % (self.dbname, collection)
 
     def _parse_addresses(self, addresses):
-        if isinstance(addresses, (str, unicode)):
+        if isinstance(addresses, six.string_types):
             addresses = [addresses]
 
         assert isinstance(addresses, list)
@@ -239,7 +240,7 @@ class Database(object):
             be added to the command document before it is sent
 
         """
-        if isinstance(command, basestring):
+        if isinstance(command, six.string_types):
             command = SON([(command, value)])
 
         command.update(kwargs)

--- a/mongotor/database.py
+++ b/mongotor/database.py
@@ -29,7 +29,7 @@ import warnings
 def initialized(fn):
     @wraps(fn)
     def wrapped(self, *args, **kwargs):
-        if not hasattr(self, '_initialized'):
+        if not hasattr(self, '_initialized') or not self._initialized:
             raise DatabaseError("you must be initialize database before perform this action")
 
         return fn(self, *args, **kwargs)
@@ -45,6 +45,7 @@ class Database(object):
     def __new__(cls):
         if not cls._instance:
             cls._instance = super(Database, cls).__new__(cls)
+            cls._initialized = False
 
         return cls._instance
 
@@ -147,7 +148,8 @@ class Database(object):
         >>> Database.disconnect()
 
         """
-        if not cls._instance or not hasattr(cls._instance, '_initialized'):
+        if (not cls._instance or not hasattr(cls._instance, '_initialized')
+                or not cls._instance._initialized):
             raise ValueError("Database isn't initialized")
 
         for node in cls._instance._nodes:

--- a/mongotor/database.py
+++ b/mongotor/database.py
@@ -122,7 +122,7 @@ class Database(object):
 
     @initialized
     def get_collection_name(self, collection):
-        return u'%s.%s' % (self.dbname, collection)
+        return '%s.%s' % (self.dbname, collection)
 
     def _parse_addresses(self, addresses):
         if isinstance(addresses, six.string_types):

--- a/mongotor/errors.py
+++ b/mongotor/errors.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-class Error(StandardError):
+class Error(Exception):
     """Base class for all mongotor exceptions.
 
     """

--- a/mongotor/helpers.py
+++ b/mongotor/helpers.py
@@ -14,6 +14,7 @@
 
 import bson
 import struct
+import six
 from mongotor.errors import (DatabaseError,
     InterfaceError, TimeoutError)
 
@@ -64,7 +65,7 @@ def _check_command_response(response, msg="%s", allowable_errors=[]):
         # Mongos returns the error details in a 'raw' object
         # for some errors.
         if "raw" in response:
-            for shard in response["raw"].itervalues():
+            for shard in six.itervalues(response["raw"]):
                 if not shard.get("ok"):
                     # Just grab the first error...
                     details = shard
@@ -92,8 +93,8 @@ def _fields_list_to_dict(fields):
     """
     as_dict = {}
     for field in fields:
-        if not isinstance(field, basestring):
+        if not isinstance(field, six.string_types):
             raise TypeError("fields must be a list of key names, "
-                            "each an instance of %s" % (basestring.__name__,))
+                            "each an instance of string (str/unicode)")
         as_dict[field] = 1
     return as_dict

--- a/mongotor/message.py
+++ b/mongotor/message.py
@@ -28,7 +28,7 @@ from bson.son import SON
 from mongotor.errors import InvalidOperationError
 
 
-__ZERO = "\x00\x00\x00\x00"
+__ZERO = b"\x00\x00\x00\x00"
 
 
 def __last_error(args):
@@ -57,7 +57,7 @@ def insert(collection_name, docs, check_keys, safe, last_error_args):
     """
     data = __ZERO
     data += bson._make_c_string(collection_name)
-    bson_data = "".join([bson.BSON.encode(doc, check_keys) for doc in docs])
+    bson_data = b"".join([bson.BSON.encode(doc, check_keys) for doc in docs])
     if not bson_data:
         raise InvalidOperationError("cannot do an empty bulk insert")
     data += bson_data

--- a/mongotor/node.py
+++ b/mongotor/node.py
@@ -65,7 +65,7 @@ class Node(object):
                                              connection=connection)
             if not connection._pool:  # if connection is created on the fly
                 connection.close()
-        except InterfaceError, ie:
+        except InterfaceError as ie:
             logger.error('oops, database node {host}:{port} is unavailable: {error}'
                          .format(host=self.host, port=self.port, error=ie))
 

--- a/mongotor/node.py
+++ b/mongotor/node.py
@@ -17,6 +17,7 @@
 
 import logging
 import random
+import six
 from tornado import gen
 from bson import SON
 from mongotor.pool import ConnectionPool
@@ -34,7 +35,7 @@ class Node(object):
         if not pool_kargs:
             pool_kargs = {}
 
-        assert isinstance(host, (str, unicode))
+        assert isinstance(host, six.string_types)
         assert isinstance(port, int)
 
         self.host = host

--- a/mongotor/orm/collection.py
+++ b/mongotor/orm/collection.py
@@ -133,7 +133,7 @@ class Collection(object):
         for (key, value) in dictionary.iteritems():
             try:
                 setattr(instance, str(key), value)
-            except TypeError, e:
+            except TypeError as e:
                 logger.warn(e)
 
         if cleaned:

--- a/mongotor/orm/collection.py
+++ b/mongotor/orm/collection.py
@@ -17,6 +17,7 @@
 
 import re
 import logging
+import six
 from tornado import gen
 from mongotor.client import Client
 from mongotor.orm.field import Field
@@ -39,7 +40,7 @@ class CollectionMetaClass(type):
         global __lazy_classes__
 
         # Add the document's fields to the _data
-        for attr_name, attr_value in attrs.iteritems():
+        for attr_name, attr_value in six.iteritems(attrs):
             if hasattr(attr_value, "__class__") and\
                     issubclass(attr_value.__class__, Field) and\
                     attr_value.name is None:
@@ -56,6 +57,7 @@ class CollectionMetaClass(type):
         return new_class
 
 
+@six.add_metaclass(CollectionMetaClass)
 class Collection(object):
     """Collection is the base class
 
@@ -74,7 +76,6 @@ class Collection(object):
     auto-generated from class name. Camel case is converted
     to snake case. For example: CamelCase -> camel_case.
     """
-    __metaclass__ = CollectionMetaClass
 
     def __new__(cls, class_name=None, *args, **kwargs):
         if class_name:
@@ -90,7 +91,7 @@ class Collection(object):
     def as_dict(self, fields=None):
         items = {}
         fields = fields or []
-        iteritems = self.__class__.__dict__.iteritems()
+        iteritems = six.iteritems(self.__class__.__dict__)
         if fields:
             iteritems = ((k,v) for k,v in iteritems if k in fields)
 
@@ -104,7 +105,7 @@ class Collection(object):
         # get the dirty fields when we only want to update those.
         if not fields:
             for cls in self.__class__.__mro__:
-                for attr_name, attr_type in cls.__dict__.iteritems():
+                for attr_name, attr_type in six.iteritems(cls.__dict__):
                     if isinstance(attr_type, Field):
                         attr_value = getattr(self, attr_name)
                         if attr_value is not None:
@@ -130,7 +131,7 @@ class Collection(object):
         >>> assert user.name == 'should be name'
         """
         instance = cls()
-        for (key, value) in dictionary.iteritems():
+        for (key, value) in six.iteritems(dictionary):
             try:
                 setattr(instance, str(key), value)
             except TypeError as e:

--- a/mongotor/orm/collection.py
+++ b/mongotor/orm/collection.py
@@ -69,6 +69,10 @@ class Collection(object):
     >>> class Users(collection.Collection):
     >>>     __collection__ = 'users'
     >>>     name = field.StringField()
+
+    If you do not specify `__collection__` attribute, it is
+    auto-generated from class name. Camel case is converted
+    to snake case. For example: CamelCase -> camel_case.
     """
     __metaclass__ = CollectionMetaClass
 

--- a/mongotor/orm/collection.py
+++ b/mongotor/orm/collection.py
@@ -35,7 +35,7 @@ class CollectionMetaClass(type):
     def __new__(cls, name, bases, attrs):
         if not attrs.get('__collection__'):
             attrs['__collection__'] = re.sub(
-                '([A-Z]+)', r'_\1', name).lower()[1:]
+                r'\B([A-Z]+)', r'_\1', name).lower()
         global __lazy_classes__
 
         # Add the document's fields to the _data

--- a/mongotor/orm/field.py
+++ b/mongotor/orm/field.py
@@ -19,7 +19,9 @@ import uuid
 import re
 import decimal
 from datetime import datetime
+import warnings
 from bson import ObjectId
+import six
 
 
 class Field(object):
@@ -63,7 +65,7 @@ class StringField(Field):
 
     def __init__(self, regex=None, *args, **kwargs):
         self.regex = re.compile(regex) if regex else None
-        super(StringField, self).__init__(field_type=unicode, *args, **kwargs)
+        super(StringField, self).__init__(field_type=six.text_type, *args, **kwargs)
 
     def _validate(self, value):
         value = super(StringField, self)._validate(value)
@@ -139,10 +141,11 @@ class IntegerField(NumberField):
         super(IntegerField, self).__init__(int, *args, **kwargs)
 
 
-class LongField(NumberField):
-
-    def __init__(self, *args, **kwargs):
-        super(LongField, self).__init__(long, *args, **kwargs)
+if six.PY2:
+    class LongField(NumberField):
+        def __init__(self, *args, **kwargs):
+            warnings.warn('LongField is deprecated, use IntegerField instead', DeprecationWarning)
+            super(LongField, self).__init__(long, *args, **kwargs)
 
 
 class FloatField(NumberField):
@@ -200,7 +203,7 @@ class Md5Field(Field):
     length = 32
 
     def __init__(self, *args, **kwargs):
-        super(Md5Field, self).__init__(field_type=unicode, *args, **kwargs)
+        super(Md5Field, self).__init__(field_type=six.text_type, *args, **kwargs)
 
     def _validate(self, value):
         value = super(Md5Field, self)._validate(value)
@@ -220,7 +223,7 @@ class Sha1Field(Field):
     length = 40
 
     def __init__(self, *args, **kwargs):
-        super(Sha1Field, self).__init__(field_type=unicode, *args, **kwargs)
+        super(Sha1Field, self).__init__(field_type=six.text_type, *args, **kwargs)
 
     def _validate(self, value):
         value = super(Sha1Field, self)._validate(value)

--- a/mongotor/orm/field.py
+++ b/mongotor/orm/field.py
@@ -67,7 +67,7 @@ class StringField(Field):
 
     def _validate(self, value):
         value = super(StringField, self)._validate(value)
-        if self.regex is not None and self.regex.match(value) is None:
+        if value is not None and self.regex is not None and self.regex.match(value) is None:
             raise(TypeError("Value did not match regex"))
 
         return value

--- a/mongotor/orm/field.py
+++ b/mongotor/orm/field.py
@@ -116,6 +116,14 @@ class NumberField(Field):
 
     def _validate(self, value):
         value = super(NumberField, self)._validate(value)
+        if value is None:
+            if self.min_value is not None:
+                value = self.min_value
+            elif self.max_value is not None:
+                value = self.max_value
+            else:
+                value = self.field_type()
+
         if self.min_value is not None and value < self.min_value:
             raise(TypeError("Value can not be less than %s" % (self.min_value)))
 

--- a/mongotor/orm/field.py
+++ b/mongotor/orm/field.py
@@ -120,7 +120,7 @@ class NumberField(Field):
             raise(TypeError("Value can not be less than %s" % (self.min_value)))
 
         if self.max_value is not None and value > self.max_value:
-            raise(TypeError("Value can not be more than %s" & (self.max_value)))
+            raise(TypeError("Value can not be more than %s" % (self.max_value)))
 
         return value
 

--- a/mongotor/orm/manager.py
+++ b/mongotor/orm/manager.py
@@ -51,6 +51,12 @@ class Manager(object):
         raise gen.Return(items)
 
     @gen.coroutine
+    def remove(self, *args, **kwargs):
+        client = Client(Database(), self.collection.__collection__)
+        result, error = yield gen.Task(client.remove, *args, **kwargs)
+        raise gen.Return(result)
+
+    @gen.coroutine
     def all(self):
         """Find all documents
 

--- a/mongotor/orm/manager.py
+++ b/mongotor/orm/manager.py
@@ -52,6 +52,10 @@ class Manager(object):
 
     @gen.coroutine
     def all(self):
+        """Find all documents
+
+        This method is alias for `find({})`
+        """
         result = yield self.find({})
         raise gen.Return(result)
 

--- a/mongotor/orm/manager.py
+++ b/mongotor/orm/manager.py
@@ -26,8 +26,8 @@ class Manager(object):
     def __init__(self, collection):
         self.collection = collection
 
-    @gen.engine
-    def find_one(self, query, callback):
+    @gen.coroutine
+    def find_one(self, query):
         client = Client(Database(), self.collection.__collection__)
         result, error = yield gen.Task(client.find_one, query)
 
@@ -35,10 +35,10 @@ class Manager(object):
         if result:
             instance = self.collection.create(result, cleaned=True)
 
-        callback(instance)
+        raise gen.Return(instance)
 
-    @gen.engine
-    def find(self, query, callback, **kw):
+    @gen.coroutine
+    def find(self, query, **kw):
         client = Client(Database(), self.collection.__collection__)
         result, error = yield gen.Task(client.find, query, **kw)
 
@@ -48,7 +48,7 @@ class Manager(object):
             for item in result:
                 items.append(self.collection.create(item, cleaned=True))
 
-        callback(items)
+        raise gen.Return(items)
 
     def count(self, query=None, callback=None):
         client = Client(Database(), self.collection.__collection__)

--- a/mongotor/orm/manager.py
+++ b/mongotor/orm/manager.py
@@ -50,6 +50,11 @@ class Manager(object):
 
         raise gen.Return(items)
 
+    @gen.coroutine
+    def all(self):
+        result = yield self.find({})
+        raise gen.Return(result)
+
     def count(self, query=None, callback=None):
         client = Client(Database(), self.collection.__collection__)
         client.find(query).count(callback=callback)

--- a/mongotor/orm/manager.py
+++ b/mongotor/orm/manager.py
@@ -65,10 +65,11 @@ class Manager(object):
         count = yield client.find(query).count()
         raise gen.Return(count)
 
-    @gen.engine
-    def distinct(self, key, callback, query=None):
+    @gen.coroutine
+    def distinct(self, key, query=None):
         client = Client(Database(), self.collection.__collection__)
-        client.find(query).distinct(key, callback=callback)
+        result = yield client.find(query).distinct(key)
+        raise gen.Return(result)
 
     @gen.engine
     def geo_near(self, near, max_distance=None, num=None, spherical=None,

--- a/mongotor/orm/manager.py
+++ b/mongotor/orm/manager.py
@@ -55,9 +55,11 @@ class Manager(object):
         result = yield self.find({})
         raise gen.Return(result)
 
-    def count(self, query=None, callback=None):
+    @gen.coroutine
+    def count(self, query=None):
         client = Client(Database(), self.collection.__collection__)
-        client.find(query).count(callback=callback)
+        count = yield client.find(query).count()
+        raise gen.Return(count)
 
     @gen.engine
     def distinct(self, key, callback, query=None):

--- a/mongotor/pool.py
+++ b/mongotor/pool.py
@@ -17,6 +17,7 @@
 import logging
 from datetime import timedelta
 from threading import Condition
+import six
 from tornado.ioloop import IOLoop
 from functools import partial
 from mongotor.connection import Connection
@@ -38,11 +39,11 @@ class ConnectionPool(object):
     def __init__(self, host, port, dbname, maxconnections=0, maxusage=0,
                  autoreconnect=True):
 
-        assert isinstance(host, (str, unicode))
+        assert isinstance(host, six.string_types)
         assert isinstance(port, int)
         assert isinstance(maxconnections, int)
         assert isinstance(maxusage, int)
-        assert isinstance(dbname, (str, unicode))
+        assert isinstance(dbname, six.string_types)
         assert isinstance(autoreconnect, bool)
 
         self._host = host

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
 
-coverage==3.5.2
-nose==1.1.2
-fudge==1.0.3
-sure==1.0.6
-spec==0.9.7
+coverage>=3.5.2
+nose>=1.1.2
+fudge>=1.0.3
+sure>=1.0.6
+spec>=0.9.7
+mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,5 @@
 coverage>=3.5.2
 nose>=1.1.2
 fudge>=1.0.3
-sure>=1.0.6
 spec>=0.9.7
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pymongo>=2.3
-tornado>=2.2
+tornado>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pymongo>=2.3
 tornado>=3.0
+six

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages():
     return packages
 
 setup(
-    name='mongotor-skd',
+    name='mongotor',
     version=version,
     description="(MongoDB + Tornado) is an asynchronous driver and toolkit for working with MongoDB inside a Tornado app",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -14,16 +14,16 @@ def get_packages():
     return packages
 
 setup(
-    name = 'mongotor',
-    version = version,
-    description = "(MongoDB + Tornado) is an asynchronous driver and toolkit for working with MongoDB inside a Tornado app",
-    long_description = open("README.md").read(),
-    keywords = ['mongo','tornado'],
-    author = 'Marcel Nicolay',
-    author_email = 'marcel.nicolay@gmail.com',
-    url = 'http://marcelnicolay.github.com/mongotor/',
-    license = 'OSI',
-    classifiers = ['Development Status :: 4 - Beta',
+    name='mongotor',
+    version=version,
+    description="(MongoDB + Tornado) is an asynchronous driver and toolkit for working with MongoDB inside a Tornado app",
+    long_description=open("README.md").read(),
+    keywords=['mongo', 'tornado'],
+    author='Marcel Nicolay',
+    author_email='marcel.nicolay@gmail.com',
+    url='http://marcelnicolay.github.com/mongotor/',
+    license='OSI',
+    classifiers=['Development Status :: 4 - Beta',
                    'Intended Audience :: Developers',
                    'License :: OSI Approved',
                    'Natural Language :: English',
@@ -32,7 +32,8 @@ setup(
                    'Programming Language :: Python :: 2.7',
                    'Topic :: Software Development :: Libraries :: Application Frameworks',
                    ],
-    install_requires = open("requirements.txt").read().split("\n"),
-    packages = get_packages(),
-    test_suite="nose.collector"
+    install_requires=open("requirements.txt").read().split("\n"),
+    packages=get_packages(),
+    test_suite="nose.collector",
+    use_2to3=True
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages():
     return packages
 
 setup(
-    name='mongotor',
+    name='mongotor-skd',
     version=version,
     description="(MongoDB + Tornado) is an asynchronous driver and toolkit for working with MongoDB inside a Tornado app",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,4 @@ setup(
     install_requires=open("requirements.txt").read().split("\n"),
     packages=get_packages(),
     test_suite="nose.collector",
-    use_2to3=True
 )

--- a/tests/orm/test_collection.py
+++ b/tests/orm/test_collection.py
@@ -177,8 +177,8 @@ class CollectionTestCase(testing.AsyncTestCase):
             __collection__ = 'collection_test'
 
         Database.disconnect()
-        CollectionTest().save.when.called_with(callback=None) \
-            .throw(DatabaseError, 'you must be initialize database before perform this action')
+        CollectionTest().save(callback=None)
+        self.assertRaises(DatabaseError, self.wait)
 
         Database.init(["localhost:27027", "localhost:27028"], dbname='test')
 

--- a/tests/orm/test_collection.py
+++ b/tests/orm/test_collection.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import six
 from tornado.ioloop import IOLoop
 from tornado import testing
 from mongotor.database import Database
@@ -6,8 +7,7 @@ from mongotor.orm.collection import Collection
 from mongotor.orm.manager import Manager
 from mongotor.orm.field import (ObjectIdField, StringField, DateTimeField,
     IntegerField, BooleanField, FloatField, ListField, ObjectField,
-    LongField, DecimalField, UrlField, UuidField, EmailField, Md5Field,
-    Sha1Field)
+    DecimalField, UrlField, UuidField, EmailField, Md5Field, Sha1Field)
 from mongotor.errors import DatabaseError
 from bson.objectid import ObjectId
 import sure
@@ -283,13 +283,17 @@ class CollectionTestCase(testing.AsyncTestCase):
             _id = ObjectIdField(default=ObjectId())
             base_url_field = UrlField(default="https://www.test.com")
             base_decimal_field = DecimalField(default=2.1)
-            base_md5_field = Md5Field(default=hashlib.md5("test").hexdigest())
+            base_md5_field = Md5Field(default=hashlib.md5(b"test").hexdigest())
 
         class ChildCollectionTest(CollectionTest):
             child_uuid_field = UuidField(default=uuid.uuid4())
             child_email_field = EmailField(default="test@test.com")
-            child_sha1_field = Sha1Field(default=hashlib.sha1("test").hexdigest())
+            child_sha1_field = Sha1Field(default=hashlib.sha1(b"test").hexdigest())
 
+        if six.PY3:  # only test LongField on python2
+            return
+
+        from mongotor.orm.field import LongField
         class SecondChildCollectionTest(ChildCollectionTest):
             second_child_long_field = LongField(default=1000)
 

--- a/tests/orm/test_collection.py
+++ b/tests/orm/test_collection.py
@@ -10,7 +10,6 @@ from mongotor.orm.field import (ObjectIdField, StringField, DateTimeField,
     DecimalField, UrlField, UuidField, EmailField, Md5Field, Sha1Field)
 from mongotor.errors import DatabaseError
 from bson.objectid import ObjectId
-import sure
 import uuid
 import hashlib
 
@@ -42,8 +41,8 @@ class CollectionTestCase(testing.AsyncTestCase):
         doc_test.save(callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_remove_a_document(self):
         """[CollectionTestCase] - Remove a document"""
@@ -62,8 +61,8 @@ class CollectionTestCase(testing.AsyncTestCase):
         doc_test.remove(callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_update_a_document(self):
         """[CollectionTestCase] - Update a document"""
@@ -83,8 +82,8 @@ class CollectionTestCase(testing.AsyncTestCase):
         doc_test.update(callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_can_create_collection_from_dictionary(self):
         """[CollectionTestCase] - Create a document from dictionary """
@@ -111,13 +110,13 @@ class CollectionTestCase(testing.AsyncTestCase):
 
         object_instance = CollectionTest.create(object_dict)
 
-        object_instance.string_attr.should.be.equal('string_attr')
-        object_instance.integer_attr.should.be.equal(1)
-        object_instance.bool_attr.should.be.ok
-        object_instance.float_attr.should.be.equal(1.0)
-        object_instance.list_attr.should.be.equal([1, 2, 3])
-        object_instance.object_attr.should.be.equal({'chave': 'valor'})
-        object_instance.object_id_attr.should.be.equal(object_id)
+        self.assertEquals(object_instance.string_attr, 'string_attr')
+        self.assertEquals(object_instance.integer_attr, 1)
+        self.assertTrue(object_instance.bool_attr)
+        self.assertEquals(object_instance.float_attr, 1.0)
+        self.assertEquals(object_instance.list_attr, [1, 2, 3])
+        self.assertEquals(object_instance.object_attr, {'chave': 'valor'})
+        self.assertEquals(object_instance.object_id_attr, object_id)
 
     def test_create_attribute_if_model_does_not_contains_field(self):
         """[CollectionTestCase] - Create attribute if model does not contains field"""
@@ -130,8 +129,8 @@ class CollectionTestCase(testing.AsyncTestCase):
         }
 
         object_instance = CollectionTest.create(object_dict)
-        object_instance.string_attr.should.be.equal('string_attr')
-        object_instance.integer_attr.should.be.equal(1)
+        self.assertEquals(object_instance.string_attr, 'string_attr')
+        self.assertEquals(object_instance.integer_attr, 1)
 
     def test_ignore_attribute_with_different_field_type(self):
         """[CollectionTestCase] - Ignore attributes with different field type"""
@@ -143,21 +142,21 @@ class CollectionTestCase(testing.AsyncTestCase):
         }
 
         object_instance = CollectionTest.create(object_dict)
-        object_instance.string_attr.should.be.none
+        self.assertIsNone(object_instance.string_attr)
 
     def test_can_set_manager_object_in_collection(self):
         """[CollectionTestCase] - Can set manager object in collection"""
         class CollectionTest(Collection):
             should_be_value = StringField()
 
-        CollectionTest.objects.should.be.a('mongotor.orm.manager.Manager')
+        self.assertIsInstance(CollectionTest.objects, Manager)
 
     def test_can_be_load_lazy_class(self):
         """[CollectionTestCase] - Can be load lazy collection"""
         class CollectionTest(Collection):
             pass
 
-        issubclass(Collection("CollectionTest"), CollectionTest).should.be.ok
+        self.assertTrue(issubclass(Collection("CollectionTest"), CollectionTest))
 
     def test_can_be_load_child_lazy_class(self):
         """[CollectionTestCase] - Can be load lazy child collection"""
@@ -167,8 +166,8 @@ class CollectionTestCase(testing.AsyncTestCase):
         class ChildCollectionTest(CollectionTest):
             pass
 
-        issubclass(Collection("ChildCollectionTest"),\
-            ChildCollectionTest).should.be.ok
+        self.assertTrue(issubclass(Collection("ChildCollectionTest"),
+                                   ChildCollectionTest))
 
     def test_raises_erro_when_use_collection_with_not_initialized_database(self):
         """[CollectionTestCase] - Raises DatabaseError when use collection with a not initialized database"""
@@ -197,8 +196,8 @@ class CollectionTestCase(testing.AsyncTestCase):
         self.wait()
 
         doc_test.string_attr = "should be new string value"
-        "string_attr".should.be.within(doc_test.dirty_fields)
-        "_id".shouldnot.be.within(doc_test.dirty_fields)
+        self.assertIn("string_attr", doc_test.dirty_fields)
+        self.assertNotIn("_id", doc_test.dirty_fields)
 
     def test_update_tracks_changed_object_attrs(self):
         """[CollectionTestCase] - Update a document and track dirty object fields"""
@@ -216,8 +215,8 @@ class CollectionTestCase(testing.AsyncTestCase):
         self.wait()
 
         doc_test.object_field = {'name': 'should be a new'}
-        "object_field".should.be.within(doc_test.dirty_fields)
-        "_id".shouldnot.be.within(doc_test.dirty_fields)
+        self.assertIn("object_field", doc_test.dirty_fields)
+        self.assertNotIn("_id", doc_test.dirty_fields)
 
     def test_load_obj_does_not_set_dirty_keys(self):
         """[CollectionTestCase] - Check if freshly loaded document has no dirty fields"""
@@ -234,7 +233,7 @@ class CollectionTestCase(testing.AsyncTestCase):
         self.wait()
         CollectionTest.objects.find_one(query=doc_test._id, callback=self.stop)
         db_doc_test = self.wait()
-        db_doc_test.dirty_fields.should.be.empty
+        self.assertEqual(len(db_doc_test.dirty_fields), 0)
 
     def test_force_update(self):
         class CollectionTest(Collection):
@@ -257,7 +256,7 @@ class CollectionTestCase(testing.AsyncTestCase):
         CollectionTest.objects.find_one(query=doc_test._id, callback=self.stop)
         db_doc_test = self.wait()
 
-        db_doc_test.string_attr.should.be.equal("changed")
+        self.assertEquals(db_doc_test.string_attr, "changed")
 
     def test_empty_callback(self):
         class CollectionTest(Collection):
@@ -275,7 +274,7 @@ class CollectionTestCase(testing.AsyncTestCase):
         doc_test.update(callback=self.stop)
         db_doc_test = self.wait()
 
-        db_doc_test.should.be(tuple())
+        self.assertIs(db_doc_test, ())
 
     def test_get_fields_from_base_classes(self):
         class CollectionTest(Collection):
@@ -299,4 +298,4 @@ class CollectionTestCase(testing.AsyncTestCase):
 
         test_instance = SecondChildCollectionTest()
         test_dict = test_instance.as_dict()
-        test_dict.should.be.length_of(8)
+        self.assertEqual(len(test_dict), 8)

--- a/tests/orm/test_manager.py
+++ b/tests/orm/test_manager.py
@@ -88,6 +88,84 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
 
         collections_found.should.have.length_of(0)
 
+    def test_remove_all(self):
+        """[ManagerTestCase] - Remove all documents from collection"""
+        collection_test = CollectionTest()
+        collection_test._id = ObjectId()
+        collection_test.string_attr = "string value"
+        collection_test.save(callback=self.stop)
+        self.wait()
+
+        other_collection_test = CollectionTest()
+        other_collection_test._id = ObjectId()
+        other_collection_test.string_attr = "other string value"
+        other_collection_test.save(callback=self.stop)
+        self.wait()
+
+        CollectionTest.objects.all(callback=self.stop)
+        collections_found = self.wait()
+        collections_found.should.have.length_of(2)
+
+        CollectionTest.objects.remove(callback=self.stop)
+        result = self.wait()
+
+        CollectionTest.objects.all(callback=self.stop)
+        collections_found = self.wait()
+        collections_found.should.have.length_of(0)
+
+    def test_remove_one_by_id(self):
+        """[ManagerTestCase] - Remove one document from collection by id"""
+        collection_test = CollectionTest()
+        collection_test._id = ObjectId()
+        collection_test.string_attr = "string value"
+        collection_test.save(callback=self.stop)
+        self.wait()
+
+        other_collection_test = CollectionTest()
+        other_collection_test._id = ObjectId()
+        other_collection_test.string_attr = "other string value"
+        other_collection_test.save(callback=self.stop)
+        self.wait()
+
+        CollectionTest.objects.all(callback=self.stop)
+        collections_found = self.wait()
+        collections_found.should.have.length_of(2)
+
+        CollectionTest.objects.remove(collection_test._id, callback=self.stop)
+        result = self.wait()
+
+        CollectionTest.objects.all(callback=self.stop)
+        collections_found = self.wait()
+        collections_found.should.have.length_of(1)
+        collections_found[0]._id.should.be.equal(other_collection_test._id)
+
+    def test_remove_one_by_spec(self):
+        """[ManagerTestCase] - Remove one document from collection by spec"""
+        collection_test = CollectionTest()
+        collection_test._id = ObjectId()
+        collection_test.string_attr = "string value"
+        collection_test.save(callback=self.stop)
+        self.wait()
+
+        other_collection_test = CollectionTest()
+        other_collection_test._id = ObjectId()
+        other_collection_test.string_attr = "other string value"
+        other_collection_test.save(callback=self.stop)
+        self.wait()
+
+        CollectionTest.objects.all(callback=self.stop)
+        collections_found = self.wait()
+        collections_found.should.have.length_of(2)
+
+        CollectionTest.objects.remove({"string_attr": "other string value"},
+            callback=self.stop)
+        result = self.wait()
+
+        CollectionTest.objects.all(callback=self.stop)
+        collections_found = self.wait()
+        collections_found.should.have.length_of(1)
+        collections_found[0]._id.should.be.equal(collection_test._id)
+
     def test_count(self):
         """[ManagerTestCase] - Count document in collection"""
         collection_test = CollectionTest()

--- a/tests/orm/test_manager.py
+++ b/tests/orm/test_manager.py
@@ -298,7 +298,7 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
         results = self.wait()
 
         self.assertEquals(4, len(results))
-        self.assertEquals({u'_id': u'Value A', u'value': 2.0}, results[0])
-        self.assertEquals({u'_id': u'Value B', u'value': 1.0}, results[1])
-        self.assertEquals({u'_id': u'Value C', u'value': 1.0}, results[2])
-        self.assertEquals({u'_id': u'Value D', u'value': 1.0}, results[3])
+        self.assertEquals({'_id': 'Value A', 'value': 2.0}, results[0])
+        self.assertEquals({'_id': 'Value B', 'value': 1.0}, results[1])
+        self.assertEquals({'_id': 'Value C', 'value': 1.0}, results[2])
+        self.assertEquals({'_id': 'Value D', 'value': 1.0}, results[3])

--- a/tests/orm/test_manager.py
+++ b/tests/orm/test_manager.py
@@ -48,8 +48,8 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
             callback=self.stop)
         collections_found = self.wait()
 
-        collections_found._id.should.be.within([collection_test._id,
-            other_collection_test._id])
+        self.assertIn(collections_found._id, [collection_test._id,
+                                              other_collection_test._id])
 
     def test_find_one_not_found(self):
         """[ManagerTestCase] - Find one when not found"""
@@ -57,7 +57,7 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
             callback=self.stop)
         collections_found = self.wait()
 
-        collections_found.should.be.none
+        self.assertIsNone(collections_found)
 
     def test_find(self):
         """[ManagerTestCase] - Find documents"""
@@ -77,8 +77,8 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
             callback=self.stop)
         collections_found = self.wait()
 
-        collections_found.should.have.length_of(1)
-        collections_found[0]._id.should.be.equal(collection_test._id)
+        self.assertEquals(len(collections_found), 1)
+        self.assertEquals(collections_found[0]._id, collection_test._id)
 
     def test_find_not_found(self):
         """[ManagerTestCase] - Find documents when not found"""
@@ -86,7 +86,7 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
             callback=self.stop)
         collections_found = self.wait()
 
-        collections_found.should.have.length_of(0)
+        self.assertEquals(len(collections_found), 0)
 
     def test_remove_all(self):
         """[ManagerTestCase] - Remove all documents from collection"""
@@ -104,14 +104,14 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
 
         CollectionTest.objects.all(callback=self.stop)
         collections_found = self.wait()
-        collections_found.should.have.length_of(2)
+        self.assertEquals(len(collections_found), 2)
 
         CollectionTest.objects.remove(callback=self.stop)
         result = self.wait()
 
         CollectionTest.objects.all(callback=self.stop)
         collections_found = self.wait()
-        collections_found.should.have.length_of(0)
+        self.assertEquals(len(collections_found), 0)
 
     def test_remove_one_by_id(self):
         """[ManagerTestCase] - Remove one document from collection by id"""
@@ -129,15 +129,15 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
 
         CollectionTest.objects.all(callback=self.stop)
         collections_found = self.wait()
-        collections_found.should.have.length_of(2)
+        self.assertEquals(len(collections_found), 2)
 
         CollectionTest.objects.remove(collection_test._id, callback=self.stop)
         result = self.wait()
 
         CollectionTest.objects.all(callback=self.stop)
         collections_found = self.wait()
-        collections_found.should.have.length_of(1)
-        collections_found[0]._id.should.be.equal(other_collection_test._id)
+        self.assertEquals(len(collections_found), 1)
+        self.assertEquals(collections_found[0]._id, other_collection_test._id)
 
     def test_remove_one_by_spec(self):
         """[ManagerTestCase] - Remove one document from collection by spec"""
@@ -155,7 +155,7 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
 
         CollectionTest.objects.all(callback=self.stop)
         collections_found = self.wait()
-        collections_found.should.have.length_of(2)
+        self.assertEquals(len(collections_found), 2)
 
         CollectionTest.objects.remove({"string_attr": "other string value"},
             callback=self.stop)
@@ -163,8 +163,8 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
 
         CollectionTest.objects.all(callback=self.stop)
         collections_found = self.wait()
-        collections_found.should.have.length_of(1)
-        collections_found[0]._id.should.be.equal(collection_test._id)
+        self.assertEquals(len(collections_found), 1)
+        self.assertEquals(collections_found[0]._id, collection_test._id)
 
     def test_count(self):
         """[ManagerTestCase] - Count document in collection"""
@@ -177,14 +177,14 @@ class ManagerTestCase(testing.AsyncTestCase, unittest.TestCase):
         CollectionTest.objects.count(callback=self.stop)
         count = self.wait()
 
-        count.should.be.equal(1)
+        self.assertEquals(count, 1)
 
     def test_count_not_found(self):
         """[ManagerTestCase] - Count document when not found"""
         CollectionTest.objects.count(callback=self.stop)
         count = self.wait()
 
-        count.should.be.equal(0)
+        self.assertEquals(count, 0)
 
     def test_find_distinct_values_with_distinct_command(self):
         """[ManagerTestCase] - Find distinct values with distinct command"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import six
 from tornado.ioloop import IOLoop
 from tornado import testing
 from mongotor.database import Database
@@ -336,7 +337,7 @@ class ClientTestCase(testing.AsyncTestCase):
 
         result, _ = self.wait()
 
-        keys = result.keys()
+        keys = list(six.iterkeys(result))
         keys.sort()
 
         keys.should.be.equal(['_id', 'comment'])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -267,11 +267,11 @@ class ClientTestCase(testing.AsyncTestCase):
 
             response = self.wait()
 
-            response['result'][0]['_id'].should.be.equal({u'tags': u'fun'})
-            response['result'][0]['authors'].should.be.equal([u'bob'])
+            response['result'][0]['_id'].should.be.equal({'tags': 'fun'})
+            response['result'][0]['authors'].should.be.equal(['bob'])
 
-            response['result'][1]['_id'].should.be.equal({u'tags': u'good'})
-            response['result'][1]['authors'].should.be.equal([u'joe', u'bob'])
+            response['result'][1]['_id'].should.be.equal({'tags': 'good'})
+            response['result'][1]['authors'].should.be.equal(['joe', 'bob'])
         finally:
             db.articles.remove({}, callback=self.stop)
             self.wait()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,6 @@ from tornado import testing
 from mongotor.database import Database
 from bson import ObjectId
 from datetime import datetime
-import sure
 
 
 class ClientTestCase(testing.AsyncTestCase):
@@ -29,8 +28,8 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.insert(document, callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_insert_a_document_list(self):
         """[ClientTestCase] - insert a list of document with client"""
@@ -44,8 +43,8 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.insert(documents, callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_remove_document_by_id(self):
         """[ClientTestCase] - remove a document by id"""
@@ -61,8 +60,8 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.remove(documents[0]['_id'], callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_remove_document_by_spec(self):
         """[ClientTestCase] - remove a document by spec"""
@@ -78,8 +77,8 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.remove({'name': 'shouldbename'}, callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_update_document(self):
         """[ClientTestCase] - update a document"""
@@ -96,8 +95,8 @@ class ClientTestCase(testing.AsyncTestCase):
             'should be a new name'}}, callback=self.stop)
         response, error = self.wait()
 
-        response['ok'].should.be.equal(1.0)
-        error.should.be.none
+        self.assertEquals(response['ok'], 1.0)
+        self.assertIsNone(error)
 
     def test_find_document(self):
         """[ClientTestCase] - find a document"""
@@ -114,9 +113,9 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.find({'someflag': 1}, callback=self.stop)
         response, error = self.wait()
 
-        response[0]['_id'].should.be.equal(documents[0]['_id'])
-        response[1]['_id'].should.be.equal(documents[1]['_id'])
-        error.should.be.none
+        self.assertEquals(response[0]['_id'], documents[0]['_id'])
+        self.assertEquals(response[1]['_id'], documents[1]['_id'])
+        self.assertIsNone(error)
 
     def test_find_one_document(self):
         """[ClientTestCase] - find one document"""
@@ -134,8 +133,8 @@ class ClientTestCase(testing.AsyncTestCase):
             callback=self.stop)
         response, error = self.wait()
 
-        response['_id'].should.be.equal(documents[1]['_id'])
-        error.should.be.none
+        self.assertEquals(response['_id'], documents[1]['_id'])
+        self.assertIsNone(error)
 
     def test_find_one_document_by_id(self):
         """[ClientTestCase] - find one document by id"""
@@ -153,8 +152,8 @@ class ClientTestCase(testing.AsyncTestCase):
             callback=self.stop)
         response, error = self.wait()
 
-        response['_id'].should.be.equal(documents[2]['_id'])
-        error.should.be.none
+        self.assertEquals(response['_id'], documents[2]['_id'])
+        self.assertIsNone(error)
 
     def test_count_documents_in_find(self):
         """[ClientTestCase] - counting documents in query"""
@@ -171,7 +170,7 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.find({"param": 'shouldbeparam1'}).count(callback=self.stop)
         total = self.wait()
 
-        total.should.be.equal(2)
+        self.assertEquals(total, 2)
 
     def test_count_all_documents(self):
         """[ClientTestCase] - counting among all documents"""
@@ -188,7 +187,7 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.count(callback=self.stop)
         total = self.wait()
 
-        total.should.be.equal(3)
+        self.assertEquals(total, 3)
 
     def test_distinct_documents_in_find(self):
         """[ClientTestCase] - distinct documents in query"""
@@ -205,8 +204,8 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.find({"param": 'shouldbeparam1'}).distinct('uuid', callback=self.stop)
         distincts = self.wait()
 
-        distincts.should.have.length_of(1)
-        distincts[0].should.be.equal(100)
+        self.assertEquals(len(distincts), 1)
+        self.assertEquals(distincts[0], 100)
 
     def test_distinct_all_documents(self):
         """[ClientTestCase] - distinct among all documents"""
@@ -223,9 +222,9 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.distinct('uuid', callback=self.stop)
         distincts = self.wait()
 
-        distincts.should.have.length_of(2)
-        distincts[0].should.be.equal(100)
-        distincts[1].should.be.equal(200)
+        self.assertEquals(len(distincts), 2)
+        self.assertEquals(distincts[0], 100)
+        self.assertEquals(distincts[1], 200)
 
     def test_aggregate_collection(self):
         """[ClientTestCase] - aggregate command"""
@@ -267,11 +266,11 @@ class ClientTestCase(testing.AsyncTestCase):
 
             response = self.wait()
 
-            response['result'][0]['_id'].should.be.equal({'tags': 'fun'})
-            response['result'][0]['authors'].should.be.equal(['bob'])
+            self.assertEquals(response['result'][0]['_id'], {'tags': 'fun'})
+            self.assertEquals(response['result'][0]['authors'], ['bob'])
 
-            response['result'][1]['_id'].should.be.equal({'tags': 'good'})
-            response['result'][1]['authors'].should.be.equal(['joe', 'bob'])
+            self.assertEquals(response['result'][1]['_id'], {'tags': 'good'})
+            self.assertEquals(response['result'][1]['authors'], ['joe', 'bob'])
         finally:
             db.articles.remove({}, callback=self.stop)
             self.wait()
@@ -312,7 +311,7 @@ class ClientTestCase(testing.AsyncTestCase):
         try:
             db.articles.group(callback=self.stop, **group)
             result = self.wait()
-            result['retval'][0]['csum'].should.be.equal(16)
+            self.assertEquals(result['retval'][0]['csum'], 16)
         finally:
             db.articles.remove({}, callback=self.stop)
             self.wait()
@@ -340,9 +339,9 @@ class ClientTestCase(testing.AsyncTestCase):
         keys = list(six.iterkeys(result))
         keys.sort()
 
-        keys.should.be.equal(['_id', 'comment'])
+        self.assertEquals(keys, ['_id', 'comment'])
 
-        str(result['_id']).should.be.equal(str(documents[0]['_id']))
-        result['comment'].should.have.length_of(1)
-        result['comment'][0]['author'].should.be.equal('joe')
-        _.should.be.none
+        self.assertEquals(str(result['_id']), str(documents[0]['_id']))
+        self.assertEquals(len(result['comment']), 1)
+        self.assertEquals(result['comment'][0]['author'], 'joe')
+        self.assertIsNone(_)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,8 +113,8 @@ class ClientTestCase(testing.AsyncTestCase):
         db.collection_test.find({'someflag': 1}, callback=self.stop)
         response, error = self.wait()
 
-        response[0]['_id'].should.be(documents[0]['_id'])
-        response[1]['_id'].should.be(documents[1]['_id'])
+        response[0]['_id'].should.be.equal(documents[0]['_id'])
+        response[1]['_id'].should.be.equal(documents[1]['_id'])
         error.should.be.none
 
     def test_find_one_document(self):
@@ -133,7 +133,7 @@ class ClientTestCase(testing.AsyncTestCase):
             callback=self.stop)
         response, error = self.wait()
 
-        response['_id'].should.be(documents[1]['_id'])
+        response['_id'].should.be.equal(documents[1]['_id'])
         error.should.be.none
 
     def test_find_one_document_by_id(self):
@@ -152,7 +152,7 @@ class ClientTestCase(testing.AsyncTestCase):
             callback=self.stop)
         response, error = self.wait()
 
-        response['_id'].should.be(documents[2]['_id'])
+        response['_id'].should.be.equal(documents[2]['_id'])
         error.should.be.none
 
     def test_count_documents_in_find(self):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -49,9 +49,9 @@ class ConnectionTestCase(testing.AsyncTestCase):
         response = helpers._unpack_response(response)
         result = response['data'][0]
 
-        result['oid'].should.be(object_id)
-        result['ok'].should.be(1.0)
-        result['str'].should.be(str(object_id))
+        result['oid'].should.be.equal(object_id)
+        result['ok'].should.be.equal(1.0)
+        result['str'].should.be.equal(str(object_id))
 
     def test_close_connection_to_mongo(self):
         """[ConnectionTestCase] - Can close connection to mongo"""
@@ -112,6 +112,7 @@ class ConnectionTestCase(testing.AsyncTestCase):
         """[ConnectionTestCase] - Raises IOError when stream throw error"""
         fake_stream = fudge.Fake()
         fake_stream.expects('write').raises(IOError())
+        fake_stream.has_attr(close=fudge.Fake().is_callable())
 
         with fudge.patched_context(self.conn, '_stream', fake_stream):
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -7,7 +7,6 @@ from mongotor import message
 from mongotor.cursor import Cursor, DESCENDING, ASCENDING
 from mongotor.database import Database
 from mongotor.node import ReadPreference
-import sure
 
 
 class CursorTestCase(testing.AsyncTestCase):
@@ -59,9 +58,9 @@ class CursorTestCase(testing.AsyncTestCase):
 
         result, error = self.wait()
 
-        result['_id'].should.be.equal(document['_id'])
-        result['name'].should.be.equal(document['name'])
-        error.should.be.none
+        self.assertEquals(result['_id'], document['_id'])
+        self.assertEquals(result['name'], document['name'])
+        self.assertIsNone(error)
 
     def test_find_documents_with_limit(self):
         """[CursorTestCase] - Find documents with limit"""
@@ -80,10 +79,10 @@ class CursorTestCase(testing.AsyncTestCase):
 
         result, error = self.wait()
 
-        result.should.have.length_of(2)
-        str(result[0]['_id']).should.be.equal(str(document1['_id']))
-        str(result[1]['_id']).should.be.equal(str(document2['_id']))
-        error.should.be.none
+        self.assertEquals(len(result), 2)
+        self.assertEquals(str(result[0]['_id']), str(document1['_id']))
+        self.assertEquals(str(result[1]['_id']), str(document2['_id']))
+        self.assertIsNone(error)
 
     def test_find_documents_with_spec(self):
         """[CursorTestCase] - Find documents with spec"""
@@ -102,10 +101,10 @@ class CursorTestCase(testing.AsyncTestCase):
 
         result, error = self.wait()
 
-        result.should.have.length_of(2)
-        str(result[0]['_id']).should.be.equal(str(document1['_id']))
-        str(result[1]['_id']).should.be.equal(str(document3['_id']))
-        error.should.be.none
+        self.assertEquals(len(result), 2)
+        self.assertEquals(str(result[0]['_id']), str(document1['_id']))
+        self.assertEquals(str(result[1]['_id']), str(document3['_id']))
+        self.assertIsNone(error)
 
     def test_find_documents_ordering_descending_by_field(self):
         """[CursorTestCase] - Find documents order descending by field"""
@@ -125,10 +124,10 @@ class CursorTestCase(testing.AsyncTestCase):
 
         result, error = self.wait()
 
-        result.should.have.length_of(2)
-        str(result[0]['_id']).should.be.equal(str(document3['_id']))
-        str(result[1]['_id']).should.be.equal(str(document2['_id']))
-        error.should.be.none
+        self.assertEquals(len(result), 2)
+        self.assertEquals(str(result[0]['_id']), str(document3['_id']))
+        self.assertEquals(str(result[1]['_id']), str(document2['_id']))
+        self.assertIsNone(error)
 
     def test_find_documents_ordering_ascending_by_field(self):
         """[CursorTestCase] - Find documents order ascending by field"""
@@ -148,10 +147,10 @@ class CursorTestCase(testing.AsyncTestCase):
 
         result, error = self.wait()
 
-        result.should.have.length_of(2)
-        str(result[0]['_id']).should.be.equal(str(document1['_id']))
-        str(result[1]['_id']).should.be.equal(str(document2['_id']))
-        error.should.be.none
+        self.assertEquals(len(result), 2)
+        self.assertEquals(str(result[0]['_id']), str(document1['_id']))
+        self.assertEquals(str(result[1]['_id']), str(document2['_id']))
+        self.assertIsNone(error)
 
     def test_find_document_by_id(self):
         """[CursorTestCase] - Find document by id"""
@@ -170,8 +169,8 @@ class CursorTestCase(testing.AsyncTestCase):
 
         result, error = self.wait()
 
-        str(result['_id']).should.be.equal(str(document2['_id']))
-        error.should.be.none
+        self.assertEquals(str(result['_id']), str(document2['_id']))
+        self.assertIsNone(error)
 
     def test_find_returning_fields(self):
         """[CursorTestCase] - Find and return only selectd fields"""
@@ -197,9 +196,9 @@ class CursorTestCase(testing.AsyncTestCase):
         keys = list(six.iterkeys(result))
         keys.sort()
 
-        keys.should.be.equal(['_id', 'comment'])
+        self.assertEquals(keys, ['_id', 'comment'])
 
-        str(result['_id']).should.be.equal(str(document1['_id']))
-        result['comment'].should.have.length_of(1)
-        result['comment'][0]['author'].should.be.equal('joe')
-        _.should.be.none
+        self.assertEquals(str(result['_id']), str(document1['_id']))
+        self.assertEquals(len(result['comment']), 1)
+        self.assertEquals(result['comment'][0]['author'], 'joe')
+        self.assertIsNone(_)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import six
 from tornado.ioloop import IOLoop
 from tornado import testing
 from bson.objectid import ObjectId
@@ -193,7 +194,7 @@ class CursorTestCase(testing.AsyncTestCase):
 
         result, _ = self.wait()
 
-        keys = result.keys()
+        keys = list(six.iterkeys(result))
         keys.sort()
 
         keys.should.be.equal(['_id', 'comment'])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,8 +6,6 @@ from mongotor.errors import DatabaseError
 from mongotor import message
 from mongotor import helpers
 from bson.objectid import ObjectId
-import sure
-import fudge
 
 
 class DatabaseTestCase(testing.AsyncTestCase):
@@ -23,13 +21,13 @@ class DatabaseTestCase(testing.AsyncTestCase):
         """[DatabaseTestCase] - Create a singleton database connection using connect method"""
         database = Database.connect("localhost:27027", dbname='test')
 
-        database.should.be.equal(Database())
+        self.assertEquals(database, Database())
 
     def test_create_singleton_database_connection(self):
         """[DatabaseTestCase] - Create a singleton database connection"""
         database = Database.init("localhost:27027", dbname='test')
 
-        database.should.be.equal(Database())
+        self.assertEquals(database, Database())
 
     def test_not_raise_when_database_was_initiated(self):
         """[DatabaseTestCase] - Not raises ValueError when connect to inititated database"""
@@ -37,7 +35,7 @@ class DatabaseTestCase(testing.AsyncTestCase):
         database1 = Database.init("localhost:27027", dbname='test')
         database2 = Database.init("localhost:27027", dbname='test')
 
-        database1.should.be.equal(database2)
+        self.assertEquals(database1, database2)
 
     def test_send_test_message(self):
         """[DatabaseTestCase] - Send a test message to database"""
@@ -54,20 +52,20 @@ class DatabaseTestCase(testing.AsyncTestCase):
 
         result = response['data'][0]
 
-        result['oid'].should.be.equal(object_id)
-        result['ok'].should.be.equal(1.0)
-        result['str'].should.be.equal(str(object_id))
+        self.assertEquals(result['oid'], object_id)
+        self.assertEquals(result['ok'], 1.0)
+        self.assertEquals(result['str'], str(object_id))
 
     def test_disconnect_database(self):
         """[DatabaseTestCase] - Disconnect the database"""
         Database.init(["localhost:27027"], dbname='test')
         Database.disconnect()
 
-        Database._instance.should.be.none
+        self.assertIsNone(Database._instance)
 
     def test_raises_error_when_disconnect_a_not_connected_database(self):
         """[DatabaseTestCase] - Raises ValueError when disconnect from a not connected database"""
-        Database.disconnect.when.called_with().throw(ValueError, "Database isn't initialized")
+        self.assertRaisesRegexp(ValueError, "Database isn't initialized", Database.disconnect)
 
     def test_raises_error_when_could_not_find_node(self):
         """[DatabaseTestCase] - Raises DatabaseError when could not find valid nodes"""
@@ -78,7 +76,8 @@ class DatabaseTestCase(testing.AsyncTestCase):
             database.send_message('', callback=self.stop)
             self.wait()
 
-        send_message.when.called.throw(DatabaseError, 'could not find an available node')
+        self.assertRaisesRegexp(DatabaseError, 'could not find an available node',
+                                send_message)
 
     def test_run_command(self):
         """[DatabaseTestCase] - Run a database command"""
@@ -87,4 +86,4 @@ class DatabaseTestCase(testing.AsyncTestCase):
         database.command('ismaster', callback=self.stop)
 
         response, error = self.wait()
-        response['ok'].should.be.ok
+        self.assertTrue(response['ok'])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -54,9 +54,9 @@ class DatabaseTestCase(testing.AsyncTestCase):
 
         result = response['data'][0]
 
-        result['oid'].should.be(object_id)
-        result['ok'].should.be(1.0)
-        result['str'].should.be(str(object_id))
+        result['oid'].should.be.equal(object_id)
+        result['ok'].should.be.equal(1.0)
+        result['str'].should.be.equal(str(object_id))
 
     def test_disconnect_database(self):
         """[DatabaseTestCase] - Disconnect the database"""

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,6 +1,5 @@
 # coding:utf-8
 import unittest
-import sure
 from mongotor.node import ReadPreference, Node
 
 
@@ -25,14 +24,14 @@ class ReadPreferenceTestCase(unittest.TestCase):
         node_found = ReadPreference.select_node([self.secondary1,
             self.secondary2, self.primary])
 
-        node_found.should.be.eql(self.primary)
+        self.assertEquals(node_found, self.primary)
 
     def test_read_preference_primary(self):
         """[ReadPreferenceTestCase] - get primary node when preference is PRIMARY"""
         node_found = ReadPreference.select_node([self.secondary1,
             self.secondary2, self.primary], ReadPreference.PRIMARY)
 
-        node_found.should.be.eql(self.primary)
+        self.assertEquals(node_found, self.primary)
 
     def test_read_preference_primary_preferred_up(self):
         """[ReadPreferenceTestCase] - get primary node when preference is PRIMARY_PREFERRED and primary is up"""
@@ -40,7 +39,7 @@ class ReadPreferenceTestCase(unittest.TestCase):
         node_found = ReadPreference.select_node([self.secondary1,
             self.secondary2, self.primary], ReadPreference.PRIMARY_PREFERRED)
 
-        node_found.should.be.eql(self.primary)
+        self.assertEquals(node_found, self.primary)
 
     def test_read_preference_primary_preferred_down(self):
         """[ReadPreferenceTestCase] - get secondary node when preference is PRIMARY_PREFERRED and primary is down"""
@@ -49,7 +48,7 @@ class ReadPreferenceTestCase(unittest.TestCase):
         node_found = ReadPreference.select_node([self.secondary1,
             self.secondary2, self.primary], ReadPreference.PRIMARY_PREFERRED)
 
-        node_found.should.be.eql(self.secondary1)
+        self.assertEquals(node_found, self.secondary1)
 
     def test_read_preference_secondary(self):
         """[ReadPreferenceTestCase] - get secondary node when preference is SECONDARY"""
@@ -57,7 +56,7 @@ class ReadPreferenceTestCase(unittest.TestCase):
         node_found = ReadPreference.select_node([self.secondary1,
             self.secondary2, self.primary], ReadPreference.SECONDARY)
 
-        node_found.should.be.eql(self.secondary1)
+        self.assertEquals(node_found, self.secondary1)
 
     def test_read_preference_secondary_preferred(self):
         """[ReadPreferenceTestCase] - get secondary node when preference is SECONDARY_PREFERRED"""
@@ -65,7 +64,7 @@ class ReadPreferenceTestCase(unittest.TestCase):
         node_found = ReadPreference.select_node([self.secondary1,
             self.secondary2, self.primary], ReadPreference.SECONDARY_PREFERRED)
 
-        node_found.should.be.eql(self.secondary1)
+        self.assertEquals(node_found, self.secondary1)
 
     def test_read_preference_secondary_preferred_down(self):
         """[ReadPreferenceTestCase] - get primary node when preference is SECONDARY_PREFERRED and secondary is down"""
@@ -74,4 +73,4 @@ class ReadPreferenceTestCase(unittest.TestCase):
         node_found = ReadPreference.select_node([self.secondary1,
             self.secondary2, self.primary], ReadPreference.SECONDARY_PREFERRED)
 
-        node_found.should.be.eql(self.primary)
+        self.assertEquals(node_found, self.primary)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import six
 from tornado.ioloop import IOLoop
 from tornado import testing
 from bson import ObjectId
@@ -45,7 +46,7 @@ class ConnectionPoolTestCase(testing.AsyncTestCase):
         pool = ConnectionPool('localhost', 27027, dbname='test', maxconnections=10)
 
         connections = []
-        for i in xrange(10):
+        for i in six.moves.range(10):
             pool.connection(self.stop)
             connections.append(self.wait())
 
@@ -83,7 +84,7 @@ class ConnectionPoolTestCase(testing.AsyncTestCase):
         message_test = message.query(0, 'mongotor_test.$cmd', 0, 1,
             {'driverOIDTest': ObjectId()})
 
-        for i in xrange(300):
+        for i in six.moves.range(300):
             pool.connection(self.stop)
             connection = self.wait()
 
@@ -108,7 +109,7 @@ class ConnectionPoolTestCase(testing.AsyncTestCase):
         message_test = message.query(0, 'mongotor_test.$cmd', 0, 1,
             {'driverOIDTest': ObjectId()})
 
-        for i in xrange(300):
+        for i in range(300):
             pool.connection(self.stop)
             connection = self.wait()
 
@@ -117,7 +118,7 @@ class ConnectionPoolTestCase(testing.AsyncTestCase):
 
         pool._idle_connections.should.have.length_of(0)
 
-        for i in xrange(300):
+        for i in six.moves.range(300):
             pool.connection(self.stop)
             connection = self.wait()
 
@@ -133,7 +134,7 @@ class ConnectionPoolTestCase(testing.AsyncTestCase):
         message_test = message.query(0, 'mongotor_test.$cmd', 0, 1,
             {'driverOIDTest': ObjectId()})
 
-        for i in xrange(30000):
+        for i in six.moves.range(30000):
             pool.connection(self.stop)
             connection = self.wait()
 

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -5,7 +5,6 @@ from bson import ObjectId
 from mongotor.errors import DatabaseError
 from mongotor.database import Database
 from mongotor.node import ReadPreference
-import sure
 import os
 import time
 
@@ -29,14 +28,14 @@ class ReplicaSetTestCase(testing.AsyncTestCase):
         master_node = ReadPreference.select_primary_node(Database()._nodes)
         secondary_node = ReadPreference.select_node(Database()._nodes, mode=ReadPreference.SECONDARY)
 
-        master_node.host.should.be.equal('localhost')
-        master_node.port.should.be.equal(27027)
+        self.assertEquals(master_node.host, 'localhost')
+        self.assertEquals(master_node.port, 27027)
 
-        secondary_node.host.should.be.equal('localhost')
-        secondary_node.port.should.be.equal(27028)
+        self.assertEquals(secondary_node.host, 'localhost')
+        self.assertEquals(secondary_node.port, 27028)
 
         nodes = Database()._nodes
-        nodes.should.have.length_of(2)
+        self.assertEquals(len(nodes), 2)
 
     def test_raises_error_when_mode_is_secondary_and_secondary_is_down(self):
         """[ReplicaSetTestCase] - Raise error when mode is secondary and secondary is down"""
@@ -48,12 +47,11 @@ class ReplicaSetTestCase(testing.AsyncTestCase):
             db._connect(callback=self.stop)
             self.wait()
 
-            Database().send_message.when.called_with((None, ''),
-                read_preference=ReadPreference.SECONDARY)\
-                .throw(DatabaseError)
+            self.assertRaises(DatabaseError, Database().send_message, (None, ''),
+                              read_preference=ReadPreference.SECONDARY)
         finally:
             os.system('make mongo-start-node2')
-            time.sleep(5)  # wait to become secondary again
+            time.sleep(8)  # wait to become secondary again
 
 
 class SecondaryPreferredTestCase(testing.AsyncTestCase):
@@ -80,4 +78,4 @@ class SecondaryPreferredTestCase(testing.AsyncTestCase):
         db.test.find_one(doc, callback=self.stop)
         doc_found, error = self.wait()
 
-        doc_found.should.be.eql(doc)
+        self.assertEquals(doc_found, doc)

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -29,11 +29,11 @@ class ReplicaSetTestCase(testing.AsyncTestCase):
         master_node = ReadPreference.select_primary_node(Database()._nodes)
         secondary_node = ReadPreference.select_node(Database()._nodes, mode=ReadPreference.SECONDARY)
 
-        master_node.host.should.be('localhost')
-        master_node.port.should.be(27027)
+        master_node.host.should.be.equal('localhost')
+        master_node.port.should.be.equal(27027)
 
-        secondary_node.host.should.be('localhost')
-        secondary_node.port.should.be(27028)
+        secondary_node.host.should.be.equal('localhost')
+        secondary_node.port.should.be.equal(27028)
 
         nodes = Database()._nodes
         nodes.should.have.length_of(2)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ deps =
     pymongo>=2.3
     nose>=1.1.2
     fudge>=1.0.3
-    sure>=1.0.6
 
 [testenv:py27]
 basepython = python2.7
@@ -21,7 +20,6 @@ deps =
     pymongo>=2.3
     nose>=1.1.2
     fudge>=1.0.3
-    sure>=1.0.6
 
 [testenv:py26-tornado23]
 basepython = python2.6
@@ -31,7 +29,6 @@ deps =
     pymongo>=2.3
     nose>=1.1.2
     fudge>=1.0.3
-    sure>=1.0.6
 
 [testenv:py27-tornado23]
 basepython = python2.7
@@ -40,7 +37,6 @@ deps =
     pymongo>=2.3
     nose>=1.1.2
     fudge>=1.0.3
-    sure>=1.0.6
 
 [testenv:py26-tornado24]
 basepython = python2.6
@@ -50,7 +46,6 @@ deps =
     pymongo>=2.3
     nose>=1.1.2
     fudge>=1.0.3
-    sure>=1.0.6
 
 [testenv:py27-tornado24]
 basepython = python2.7
@@ -59,4 +54,3 @@ deps =
     pymongo>=2.3
     nose>=1.1.2
     fudge>=1.0.3
-    sure>=1.0.6


### PR DESCRIPTION
Currently overriding `Field.name` not works as expected:

``` python
class CollectionTest(Collection):
    new_field = StringField(name='string_attr')
```

I added a failing test in one commit, and next fixed it.

(This branch is based on tahajahangir/coroutine-py3, see [network](https://github.com/tahajahangir/mongotor/network))
