### PR TITLE
Fix using mutable/callable defaults

### DIFF
--- a/mongotor/orm/field.py
+++ b/mongotor/orm/field.py
@@ -28,7 +28,7 @@ class Field(object):
 
         self.field_type = field_type
         self.name = name
-        self.default = self._validate(default)
+        self.default = default if callable(default) else self._validate(default)
 
     def __get__(self, instance, owner):
         if not instance:
@@ -36,7 +36,11 @@ class Field(object):
 
         value = instance._data.get(self.name)
         if value is None:
-            return self.default() if callable(self.default) else self.default
+            if not callable(self.default):
+                value = self.default
+            else:
+                value = self.default()
+                self.__set__(instance, value)  # save new value on instance itself
 
         return value
 

--- a/tests/orm/test_collection.py
+++ b/tests/orm/test_collection.py
@@ -259,6 +259,26 @@ class CollectionTestCase(testing.AsyncTestCase):
 
         db_doc_test.string_attr.should.be.equal("changed")
 
+    def test_field_default_value(self):
+        class CollectionTest(Collection):
+            int_field = IntegerField(default=2)
+            dict_field = ObjectField(default=lambda: dict())
+
+        doc = CollectionTest()
+        self.assertEqual(doc.int_field, 2)
+        # not-None default values should exists in as_dict output
+        self.assertIn('int_field', doc.as_dict())
+
+        doc_dict_field = doc.dict_field  # default callables should work
+        self.assertEqual(doc_dict_field, {})
+        # accessing the field twice, should return the same object
+        self.assertIs(doc_dict_field, doc.dict_field)
+        self.assertIs(doc.as_dict()['dict_field'], doc_dict_field)
+
+        # another document's field should be different object
+        doc2 = CollectionTest()
+        self.assertIsNot(doc2.dict_field, doc_dict_field)
+
     def test_empty_callback(self):
         class CollectionTest(Collection):
             __collection__ = "collection_test"


### PR DESCRIPTION
This pull request contains tests and fixes about using callable defaults, like:

``` python
class CollectionTest(Collection):
    dict_field = ObjectField(default=lambda: dict())
    int_field = IntegerField(default=2)
```
