### PR TITLE
Fix invalid 32bit int range for request_id

### DIFF
--- a/mongotor/message.py
+++ b/mongotor/message.py
@@ -44,7 +44,7 @@ def __pack_message(operation, data):
 
     Returns the resultant message string.
     """
-    request_id = random.randint(-2 ** 31 - 1, 2 ** 31)
+    request_id = random.randint(-2147483648, 2147483647)  # -2^31 to 2^31 - 1
     message = struct.pack("<i", 16 + len(data))
     message += struct.pack("<i", request_id)
     message += __ZERO  # responseTo


### PR DESCRIPTION
Request id should be in range [-2^31, 2^31 - 1] not [-2^31 - 1, 2^31]

This is the traceback:

```
....
  File "lib/python2.7/site-packages/mongotor/cursor.py", line 77, in find
    self._skip, self._limit, self._query_spec(), self._fields)
  File "lib/python2.7/site-packages/mongotor/message.py", line 105, in query
    return __pack_message(2004, data)
  File "lib/python2.7/site-packages/mongotor/message.py", line 49, in __pack_message
    message += struct.pack("<i", request_id)
error: 'i' format requires -2147483648 <= number <= 2147483647
```

The probability of giving out-of-range number in current code is `0.00000000047` but this happened!
